### PR TITLE
Made converting column types to json more robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ivcap_df"
-version = "0.3.0"
+version = "0.3.1"
 description = "Library to model, search, and work with linked data in IVCAP"
 authors = ["Max Ott <max.ott@csiro.au>"]
 license = "BSD-3"

--- a/src/ivcap_df/ivcap/ivcap_connector.py
+++ b/src/ivcap_df/ivcap/ivcap_connector.py
@@ -83,7 +83,10 @@ class IvcapConnector(Connector):
                 if col.ctype == ColType.UUID:
                     el = str(el) if isinstance(el, uuid.UUID) else None
                 elif col.ctype == ColType.REF:
-                    el = el if not pd.isnull(el) else "urn:error:undefined"
+                    if not pd.isnull(el):
+                        pass # already in the right format
+                    else:
+                        el = "urn:error:undefined" if col.required else None
                 elif col.ctype == ColType.DATETIME64_NS_TZ:
                     try:
                         el = str(el.to_datetime64()) if not pd.isnull(el) else None
@@ -91,7 +94,10 @@ class IvcapConnector(Connector):
                         if isinstance(el, datetime):
                             el = el.isoformat()
                         else:
-                            raise Exception(f"Column '{col.name}' doesn't contain datetime value - '{ex}'")
+                            if isinstance(el, str):
+                                pass # ok, already a string. TODO: Maybe we should check if string is properly formatted
+                            else:
+                                raise Exception(f"Column '{col.name}' doesn't contain datetime value - '{ex}'")
                     
                 if el == None or pd.isna(el):
                     continue


### PR DESCRIPTION
Specifically if type is DATETIME but the value is string, we currently just take it (should verify format in the future)
Also if a reference is not defined and not required, we now skip that - as intended.